### PR TITLE
Fixed bug in preprocessing Xw for loglin

### DIFF
--- a/R/pciloglin.R
+++ b/R/pciloglin.R
@@ -187,6 +187,7 @@ p2sls.loglin <- function(Y, offset = rep(0, length(Y)),
         Xw0 <- lapply(Xw, function(xwi) {
           xw <- as.matrix(xwi)
           colnames(xw) <- colnames(xwi)
+          return(xw)
         })
       }
     }


### PR DESCRIPTION
The lapply() which preprocesses Xw did not return the variable, like it does in the other pci functions. The following error was enocuntered:

`Error in cbind(t, d, w, eta, x)[order(t), ] : subscript out of bounds`

I added this line, resolving the error. 