### PR TITLE
Fixed small bug in cumhaz calculation

### DIFF
--- a/R/p2sls.ah.survfunc.R
+++ b/R/p2sls.ah.survfunc.R
@@ -384,7 +384,7 @@ p2sls.ah.survfunc <- function(Y, D, A, a, X = NULL, W, Z = NULL, Xw = NULL,
   }
   
   cumhaz0_k <- cumsum(haz0_k)
-  cumhaz0_2s <- stepfun(x = unique(t1), y = c(0, cumhaz_k))
+  cumhaz0_2s <- stepfun(x = unique(t1), y = c(0, cumhaz0_k))
   
   if (is.null(tmax)) {
     tmax <- max(t1) * 1.05


### PR DESCRIPTION
The function would not run as cumhaz_k was not defined. I think this should just be cumhaz0_k. Is that correct? I changed it accordingly, and it does run without error.